### PR TITLE
Make ThemeProvider singleton using Hilt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id(GradlePluginId.ANDROID_APPLICATION)
     id(GradlePluginId.KOTLIN_ANDROID)
     id(GradlePluginId.KOTLIN_KAPT)
+    id(GradlePluginId.HILT)
 }
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
         android:theme="@style/Theme.LayoutOverlay">
         <activity
             android:name=".MainActivity"
-            android:theme="@style/Theme.LayoutOverlay"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <application
+        android:name=".BaseApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -14,6 +15,7 @@
         android:theme="@style/Theme.LayoutOverlay">
         <activity
             android:name=".MainActivity"
+            android:theme="@style/Theme.LayoutOverlay"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/casper/layoutoverlay/BaseApplication.kt
+++ b/app/src/main/java/com/casper/layoutoverlay/BaseApplication.kt
@@ -1,0 +1,23 @@
+package com.casper.layoutoverlay
+
+import android.app.Application
+import androidx.appcompat.app.AppCompatDelegate
+import com.casper.layoutoverlay.shared.ThemeProvider
+import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
+
+@HiltAndroidApp
+class BaseApplication : Application() {
+    @Inject
+    lateinit var themeProvider: ThemeProvider
+
+    override fun onCreate() {
+        super.onCreate()
+        setTheme()
+    }
+
+    private fun setTheme() {
+        val theme = themeProvider.getThemeFromPreferences()
+        AppCompatDelegate.setDefaultNightMode(theme)
+    }
+}

--- a/app/src/main/java/com/casper/layoutoverlay/MainActivity.kt
+++ b/app/src/main/java/com/casper/layoutoverlay/MainActivity.kt
@@ -2,12 +2,12 @@ package com.casper.layoutoverlay
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.casper.layoutoverlay.databinding.ActivityMainBinding
-import com.casper.layoutoverlay.shared.ThemeProvider
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
 
@@ -15,9 +15,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
         initBottomNavigation()
-        setTheme()
     }
 
     private fun initBottomNavigation() {
@@ -25,10 +23,5 @@ class MainActivity : AppCompatActivity() {
             .findFragmentById(R.id.nav_host_fragment_container) as NavHostFragment
         val navController = navHostFragment.navController
         binding.bottomNav.setupWithNavController(navController)
-    }
-
-    private fun setTheme() {
-        val theme = ThemeProvider.getInstance(this).getThemeFromPreferences()
-        AppCompatDelegate.setDefaultNightMode(theme)
     }
 }

--- a/app/src/main/java/com/casper/layoutoverlay/MainActivity.kt
+++ b/app/src/main/java/com/casper/layoutoverlay/MainActivity.kt
@@ -28,7 +28,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setTheme() {
-        val theme = ThemeProvider(this).getThemeFromPreferences()
+        val theme = ThemeProvider.getInstance(this).getThemeFromPreferences()
         AppCompatDelegate.setDefaultNightMode(theme)
     }
 }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.LayoutOverlay" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.LayoutOverlay" parent="Theme.MaterialComponents.DayNight">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     id(GradlePluginId.ANDROID_LIBRARY)
     id(GradlePluginId.KOTLIN_ANDROID)
+    id(GradlePluginId.KOTLIN_KAPT)
+    id(GradlePluginId.HILT)
 }
 
 android {
@@ -38,6 +40,9 @@ dependencies {
     api(libs.appcompat)
     api(libs.material)
     api(libs.preference)
+    api(libs.hilt)
+    kapt(libs.hilt.compiler)
+
     testApi(libs.bundles.test)
     testRuntimeOnly(libs.junit.jupiter.engine)
     androidTestApi(libs.bundles.androidTest)

--- a/feature/settings/src/main/java/com/casper/layoutoverlay/settings/presentation/SettingsFragment.kt
+++ b/feature/settings/src/main/java/com/casper/layoutoverlay/settings/presentation/SettingsFragment.kt
@@ -11,10 +11,10 @@ import com.casper.layoutoverlay.shared.ThemeProvider
 class SettingsFragment : PreferenceFragmentCompat() {
 
     private val themeProvider by lazy {
-        ThemeProvider(requireContext())
+        ThemeProvider.getInstance(requireContext())
     }
     private val themePreference by lazy {
-        findPreference<ListPreference>(getString(com.casper.layoutoverlay.shared.R.string.preference_key_theme))
+        findPreference<ListPreference>(getString(ThemeProvider.PREF_KEY_THEME_RESOURCE_ID))
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {

--- a/feature/settings/src/main/java/com/casper/layoutoverlay/settings/presentation/SettingsFragment.kt
+++ b/feature/settings/src/main/java/com/casper/layoutoverlay/settings/presentation/SettingsFragment.kt
@@ -7,12 +7,13 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.casper.layoutoverlay.settings.R
 import com.casper.layoutoverlay.shared.ThemeProvider
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class SettingsFragment : PreferenceFragmentCompat() {
 
-    private val themeProvider by lazy {
-        ThemeProvider.getInstance(requireContext())
-    }
+    @Inject lateinit var themeProvider: ThemeProvider
     private val themePreference by lazy {
         findPreference<ListPreference>(getString(ThemeProvider.PREF_KEY_THEME_RESOURCE_ID))
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     id(GradlePluginId.ANDROID_LIBRARY)
     id(GradlePluginId.KOTLIN_ANDROID)
+    id(GradlePluginId.KOTLIN_KAPT)
+    id(GradlePluginId.HILT)
 }
 
 android {
@@ -37,6 +39,9 @@ dependencies {
     api(libs.appcompat)
     api(libs.material)
     api(libs.preference)
+    api(libs.hilt)
+    kapt(libs.hilt.compiler)
+
     testApi(libs.bundles.test)
     testRuntimeOnly(libs.junit.jupiter.engine)
     androidTestApi(libs.bundles.androidTest)

--- a/shared/src/main/java/com/casper/layoutoverlay/shared/ThemeProvider.kt
+++ b/shared/src/main/java/com/casper/layoutoverlay/shared/ThemeProvider.kt
@@ -1,16 +1,17 @@
 package com.casper.layoutoverlay.shared
 
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
 import java.security.InvalidParameterException
 
-class ThemeProvider(private val context: Context) {
+class ThemeProvider private constructor(private val context: Context) {
 
     fun getThemeFromPreferences(): Int {
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
         val selectedTheme = sharedPreferences.getString(
-            context.getString(R.string.preference_key_theme),
+            context.getString(PREF_KEY_THEME_RESOURCE_ID),
             context.getString(R.string.preference_theme_key_system)
         )
 
@@ -32,4 +33,19 @@ class ThemeProvider(private val context: Context) {
             context.getString(R.string.preference_theme_key_light) -> context.getString(R.string.preference_theme_name_light)
             else -> context.getString(R.string.preference_theme_name_system)
         }
+
+    companion object {
+        @SuppressLint("StaticFieldLeak")
+        @Volatile
+        private var INSTANCE: ThemeProvider? = null
+
+        val PREF_KEY_THEME_RESOURCE_ID = R.string.preference_key_theme
+
+        fun getInstance(context: Context): ThemeProvider =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: ThemeProvider(context).also {
+                    INSTANCE = it
+                }
+            }
+    }
 }

--- a/shared/src/main/java/com/casper/layoutoverlay/shared/ThemeProvider.kt
+++ b/shared/src/main/java/com/casper/layoutoverlay/shared/ThemeProvider.kt
@@ -1,12 +1,16 @@
 package com.casper.layoutoverlay.shared
 
-import android.annotation.SuppressLint
 import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
 import java.security.InvalidParameterException
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class ThemeProvider private constructor(private val context: Context) {
+@Singleton
+class ThemeProvider @Inject constructor(
+    private val context: Context
+) {
 
     fun getThemeFromPreferences(): Int {
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
@@ -35,17 +39,8 @@ class ThemeProvider private constructor(private val context: Context) {
         }
 
     companion object {
-        @SuppressLint("StaticFieldLeak")
-        @Volatile
-        private var INSTANCE: ThemeProvider? = null
 
         val PREF_KEY_THEME_RESOURCE_ID = R.string.preference_key_theme
 
-        fun getInstance(context: Context): ThemeProvider =
-            INSTANCE ?: synchronized(this) {
-                INSTANCE ?: ThemeProvider(context).also {
-                    INSTANCE = it
-                }
-            }
     }
 }

--- a/shared/src/main/java/com/casper/layoutoverlay/shared/di/PreferenceModule.kt
+++ b/shared/src/main/java/com/casper/layoutoverlay/shared/di/PreferenceModule.kt
@@ -1,0 +1,21 @@
+package com.casper.layoutoverlay.shared.di
+
+import android.content.Context
+import com.casper.layoutoverlay.shared.ThemeProvider
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+class PreferenceModule {
+
+    @Singleton
+    @Provides
+    fun provideThemeProvider(@ApplicationContext context: Context): ThemeProvider {
+        return ThemeProvider(context)
+    }
+}


### PR DESCRIPTION
- Hilt 를 이용하여 ThemeProvider 싱글턴 제공
- Settings 모듈에서 Shared 모듈의 리소스를 직접 참조하는 대신 상수값 참조하도록 변경
- theme 설정 시점 Activity->Application
  - Activity.onCreate 에서 수행 시 uiMode 값 변경에 따라 Activity 새로 생성 됨
  - Application 에 해당 로직을 넣어 Activity 두 번 생성되지 않게 적용 가능

TODO: 다크 모드로 앱 설정, 시스템은 light 일 때 앱 종료 상태에서 진입 시 white 윈도우 보여졌다가 뒤늦게 바뀌는 이슈